### PR TITLE
Hide bluetooth page when bluetooth settings schema missing

### DIFF
--- a/src/Widgets/SettingsView.vala
+++ b/src/Widgets/SettingsView.vala
@@ -37,13 +37,14 @@ public class Sharing.Widgets.SettingsView : Gtk.Stack {
     }
 
     private void load_pages () {
-        BluetoothPage bluetooth_page = new BluetoothPage ();
+        if (GLib.SettingsSchemaSource.get_default ().lookup ("org.pantheon.desktop.wingpanel.indicators.bluetooth", false) != null) {
+            BluetoothPage bluetooth_page = new BluetoothPage ();
+            this.add_named (bluetooth_page, bluetooth_page.id);
+            settings_pages.@set (bluetooth_page.id, bluetooth_page);
+        }
+
         DLNAPage dlna_page = new DLNAPage ();
-
-        settings_pages.@set (bluetooth_page.id, bluetooth_page);
         settings_pages.@set (dlna_page.id, dlna_page);
-
-        this.add_named (bluetooth_page, bluetooth_page.id);
         this.add_named (dlna_page, dlna_page.id);
     }
 }


### PR DESCRIPTION
This hides the bluetooth page when the settings schema is missing, this does stop the use of the bluetooth page naturally however the service state update is dependent on the schema, so in order to remove that dependency we would need to add a fallback or just switch to a different backend for this, anyways this is better than a segfault.

Fixes #16 