### PR TITLE
Disable content grid child switches when service switch is off

### DIFF
--- a/po/gl.po
+++ b/po/gl.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: sharing-plug\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2019-09-12 14:23+0000\n"
-"Last-Translator: Daniel <riesp@protonmail.com>\n"
+"PO-Revision-Date: 2019-09-30 14:23+0000\n"
+"Last-Translator: Daniel R. <riesp@pm.me>\n"
 "Language-Team: Galician <https://l10n.elementary.io/projects/switchboard/"
 "switchboard-plug-sharing/gl/>\n"
 "Language: gl\n"
@@ -54,7 +54,7 @@ msgstr ""
 
 #: src/Widgets/ServiceEntry.vala:25
 msgid "Connected"
-msgstr ""
+msgstr "Conectado"
 
 #: src/Widgets/ServiceEntry.vala:26
 msgid "Disabled"

--- a/src/Widgets/SettingsPage.vala
+++ b/src/Widgets/SettingsPage.vala
@@ -132,7 +132,7 @@ public abstract class Sharing.Widgets.SettingsPage : Gtk.Grid {
             subtitle_label.set_label (state == ServiceState.DISABLED ? disabled_description : enabled_description);
             service_switch.set_active (state != ServiceState.DISABLED);
             content_grid.set_sensitive (state != ServiceState.DISABLED);
-            update_content_grid_state(state);
+            update_content_grid_state (state);
         }
 
         if (service_entry != null) {
@@ -144,9 +144,9 @@ public abstract class Sharing.Widgets.SettingsPage : Gtk.Grid {
 
     protected void update_content_grid_state (ServiceState state) {
         if (state == ServiceState.DISABLED) {
-            foreach(Gtk.Widget widget in content_grid.get_children()) {
+            foreach (Gtk.Widget widget in content_grid.get_children ()) {
                 if (widget is Gtk.Switch) {
-                    ((Gtk.Switch)widget).set_active(false);
+                    ((Gtk.Switch)widget).set_active (false);
                 }
             }
         }

--- a/src/Widgets/SettingsPage.vala
+++ b/src/Widgets/SettingsPage.vala
@@ -132,6 +132,7 @@ public abstract class Sharing.Widgets.SettingsPage : Gtk.Grid {
             subtitle_label.set_label (state == ServiceState.DISABLED ? disabled_description : enabled_description);
             service_switch.set_active (state != ServiceState.DISABLED);
             content_grid.set_sensitive (state != ServiceState.DISABLED);
+            update_content_grid_state(state);
         }
 
         if (service_entry != null) {
@@ -139,5 +140,15 @@ public abstract class Sharing.Widgets.SettingsPage : Gtk.Grid {
         }
 
         service_state = state;
+    }
+
+    protected void update_content_grid_state (ServiceState state) {
+        if (state == ServiceState.DISABLED) {
+            foreach(Gtk.Widget widget in content_grid.get_children()) {
+                if (widget is Gtk.Switch) {
+                    ((Gtk.Switch)widget).set_active(false);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #1 - Change all child switches to off when parent switch is off