### PR TITLE
DLNAPage: Rewrite without FileChooserButton

### DIFF
--- a/src/Widgets/DLNAPage.vala
+++ b/src/Widgets/DLNAPage.vala
@@ -129,6 +129,8 @@ public class Sharing.Widgets.DLNAPage : Granite.SimpleSettingsPage {
             attach (header, 2, 0);
             attach (location_button, 2, 1);
 
+            check.bind_property ("active", image, "sensitive");
+
             check.toggled.connect (() => {
                 config_file.set_media_type_enabled (media_type, check.active);
                 config_file.save ();

--- a/src/Widgets/DLNAPage.vala
+++ b/src/Widgets/DLNAPage.vala
@@ -143,8 +143,11 @@ public class Sharing.Widgets.DLNAPage : Granite.SimpleSettingsPage {
             folder_name.label = folder_dir;
             location_dialog.response.connect ((response) => {
                 if (response == Gtk.ResponseType.ACCEPT) {
-                    var file = location_dialog.get_file ();
-                    folder_name.label = file.get_path ();
+                    var file_path = location_dialog.get_file ().get_path ();
+                    folder_name.label = file_path;
+
+                    config_file.set_media_type_folder (media_type, file_path);
+                    config_file.save ();
                 }
             });
         }

--- a/src/Widgets/DLNAPage.vala
+++ b/src/Widgets/DLNAPage.vala
@@ -7,8 +7,6 @@ public class Sharing.Widgets.DLNAPage : Granite.SimpleSettingsPage {
     private Backend.RygelStartupManager rygel_startup_manager;
     private Backend.RygelConfigFile rygel_config_file;
 
-    private int content_area_rows = 0;
-
     public DLNAPage () {
         Object (
             activatable: true,
@@ -23,65 +21,22 @@ public class Sharing.Widgets.DLNAPage : Granite.SimpleSettingsPage {
         rygel_startup_manager = new Backend.RygelStartupManager ();
         rygel_config_file = new Backend.RygelConfigFile ();
 
-        add_media_entry ("music", _("Music"));
-        add_media_entry ("videos", _("Videos"));
-        add_media_entry ("pictures", _("Photos"));
+        var music_entry = new MediaEntry ("music", _("Music Folder"), rygel_config_file);
+        var videos_entry = new MediaEntry ("videos", _("Videos Folder"), rygel_config_file);
+        var pictures_entry = new MediaEntry ("pictures", _("Pictures Folder"), rygel_config_file);
+
+        var box = new Gtk.Box (VERTICAL, 24);
+        box.add (music_entry);
+        box.add (videos_entry);
+        box.add (pictures_entry);
+
+        content_area.attach (box, 0, 0);
 
         set_service_state ();
 
         status_switch.notify["active"].connect (() => {
             set_service_state ();
         });
-    }
-
-    private static string replace_xdg_folders (string folder_path) {
-        switch (folder_path) {
-            case "@MUSIC@": return Environment.get_user_special_dir (UserDirectory.MUSIC);
-            case "@VIDEOS@": return Environment.get_user_special_dir (UserDirectory.VIDEOS);
-            case "@PICTURES@": return Environment.get_user_special_dir (UserDirectory.PICTURES);
-            default: return folder_path;
-        }
-    }
-    private void add_media_entry (string media_type_id, string media_type_name) {
-        bool is_enabled = rygel_config_file.get_media_type_enabled (media_type_id);
-        string folder_path = rygel_config_file.get_media_type_folder (media_type_id);
-
-        var entry_label = new Gtk.Label ("%s:".printf (media_type_name));
-        entry_label.halign = Gtk.Align.END;
-
-        var entry_file_chooser = new Gtk.FileChooserButton (_("Select the folder containing your %s").printf (media_type_name), Gtk.FileChooserAction.SELECT_FOLDER);
-        entry_file_chooser.hexpand = true;
-        entry_file_chooser.sensitive = is_enabled;
-        entry_file_chooser.file_set.connect (() => {
-            rygel_config_file.set_media_type_folder (media_type_id, entry_file_chooser.get_file ().get_path ());
-            rygel_config_file.save ();
-        });
-
-        try {
-            if (folder_path != "") {
-                entry_file_chooser.set_file (File.new_for_path (replace_xdg_folders (folder_path)));
-            }
-        } catch (Error e) {
-            warning ("The folder path %s is invalid: %s", folder_path, e.message);
-        }
-
-        var entry_switch = new Gtk.Switch ();
-        entry_switch.valign = Gtk.Align.CENTER;
-        entry_switch.state = is_enabled;
-        entry_switch.state_set.connect ((state) => {
-            entry_file_chooser.set_sensitive (state);
-
-            rygel_config_file.set_media_type_enabled (media_type_id, state);
-            rygel_config_file.save ();
-
-            return false;
-        });
-
-        content_area.attach (entry_label, 0, content_area_rows, 1, 1);
-        content_area.attach (entry_file_chooser, 1, content_area_rows, 1, 1);
-        content_area.attach (entry_switch, 2, content_area_rows, 1, 1);
-
-        content_area_rows++;
     }
 
     private void set_service_state () {
@@ -99,6 +54,106 @@ public class Sharing.Widgets.DLNAPage : Granite.SimpleSettingsPage {
             description = _("While disabled, the selected media libraries are unshared, and it won't stream files from your computer to other devices.");
             status = _("Disabled");
             status_type = OFFLINE;
+        }
+    }
+
+    private class MediaEntry : Gtk.Grid {
+        public string label { get; construct; }
+        public string media_type { get; construct; }
+        public unowned Backend.RygelConfigFile config_file { get; construct; }
+
+        private Gtk.Label folder_name;
+
+        public MediaEntry (string media_type, string label, Backend.RygelConfigFile config_file) {
+            Object (
+                config_file: config_file,
+                media_type: media_type,
+                label: label
+            );
+        }
+
+        construct {
+            var folder_dir = replace_xdg_folders (config_file.get_media_type_folder (media_type));
+
+            var check = new Gtk.CheckButton () {
+                active = config_file.get_media_type_enabled (media_type),
+                valign = CENTER
+            };
+
+            var icon_name = "";
+            switch (media_type) {
+                case "music":
+                    icon_name = "audio-x-generic";
+                    break;
+                case "pictures":
+                    icon_name = "image-x-generic";
+                    break;
+                case "videos":
+                    icon_name = "video-x-generic";
+                    break;
+            }
+
+            var image = new Gtk.Image.from_icon_name (icon_name, DND) {
+                pixel_size = 32
+            };
+
+            var header = new Granite.HeaderLabel (label);
+
+            folder_name = new Gtk.Label ("") {
+                halign = START,
+                hexpand = true
+            };
+
+            var arrow = new Gtk.Image.from_icon_name ("view-more-horizontal-symbolic", BUTTON);
+
+            var location_button_box = new Gtk.Box (HORIZONTAL, 3);
+            location_button_box.add (folder_name);
+            location_button_box.add (arrow);
+
+            var location_button = new Gtk.Button () {
+                child = location_button_box
+            };
+
+            var location_dialog = new Gtk.FileChooserNative (
+                _("Select Screenshots Folder…"),
+                ((Gtk.Application) Application.get_default ()).active_window,
+                Gtk.FileChooserAction.SELECT_FOLDER,
+                _("Select"),
+                null
+            );
+            location_dialog.set_current_folder (folder_dir);
+
+            column_spacing = 12;
+            attach (check, 0, 0, 1, 2);
+            attach (image, 1, 0, 1, 2);
+            attach (header, 2, 0);
+            attach (location_button, 2, 1);
+
+            check.toggled.connect (() => {
+                config_file.set_media_type_enabled (media_type, check.active);
+                config_file.save ();
+            });
+
+            location_button.clicked.connect (() => {
+                location_dialog.run ();
+            });
+
+            folder_name.label = folder_dir;
+            location_dialog.response.connect ((response) => {
+                if (response == Gtk.ResponseType.ACCEPT) {
+                    var file = location_dialog.get_file ();
+                    folder_name.label = file.get_path ();
+                }
+            });
+        }
+
+        private string replace_xdg_folders (string folder_path) {
+            switch (folder_path) {
+                case "@MUSIC@": return Environment.get_user_special_dir (UserDirectory.MUSIC);
+                case "@VIDEOS@": return Environment.get_user_special_dir (UserDirectory.VIDEOS);
+                case "@PICTURES@": return Environment.get_user_special_dir (UserDirectory.PICTURES);
+                default: return folder_path;
+            }
         }
     }
 }


### PR DESCRIPTION
![Screenshot from 2023-10-14 12 09 01](https://github.com/elementary/switchboard-plug-sharing/assets/7277719/e37aadc8-e57f-46f2-b65e-fb90b1461c64)

No FileChooserButton in GTK 4, so make our own. While here:

* Use checkbuttons instead of switches since we're selecting items to include in a list
* Show media type icons like we do in Privacy settings
* I didn't bind file button sensitivity to the checkbutton so that you can set which folder you'd like to share before starting sharing