### PR TITLE
DLNAPage: Fix title of Gtk.FileChooserNative

### DIFF
--- a/src/Widgets/DLNAPage.vala
+++ b/src/Widgets/DLNAPage.vala
@@ -116,7 +116,7 @@ public class Sharing.Widgets.DLNAPage : Granite.SimpleSettingsPage {
             };
 
             var location_dialog = new Gtk.FileChooserNative (
-                _("Select Screenshots Folder…"),
+                _("Select %s…").printf (label),
                 ((Gtk.Application) Application.get_default ()).active_window,
                 Gtk.FileChooserAction.SELECT_FOLDER,
                 _("Select"),


### PR DESCRIPTION
We don't handle anything related to screenshot so the current title sounds a little bit out of place for me.