### PR TITLE
Actions: Use development-target

### DIFF
--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/elementary/docker:next-unstable
+      image: ghcr.io/elementary/docker:development-target
 
     steps:
     - name: Install git
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.GIT_USER_TOKEN }}
 
     - name: Update Translation Files
-      uses: elementary/actions/gettext-template@next
+      uses: elementary/actions/gettext-template@main
       env:
         GIT_USER_TOKEN: ${{ secrets.GIT_USER_TOKEN }}
         GIT_USER_NAME: "elementaryBot"

--- a/.github/workflows/gettext.yml
+++ b/.github/workflows/gettext.yml
@@ -1,21 +1,12 @@
 name: Gettext Updates
-
 on:
   push:
     branches: [main]
-
 jobs:
-  build:
+  gettext_template:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/elementary/docker:development-target
 
     steps:
-    - name: Install git
-      run: |
-        apt-get update
-        apt-get install git -y
-
     - name: Clone repository
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This should fixes the gettext actions failing in the recent main branch.

The current gettext actions runs on `next-unstable` which built on Ubuntu 22.04 LTS. So, it can't meet the requirement of `libgtk-4-dev (>= 4.10)` defined in the control file and reporting the `you have held broken packages` error.

From [the latest log](https://github.com/elementary/switchboard-plug-sharing/actions/runs/8443564115/job/23127446613):

```
Setting up libgtk-4-1:amd64 (4.6.9+ds-0ubuntu0.22.04.1) ...
Setting up libmutter-10-dev:amd64 (42.9-0ubuntu5) ...
Setting up libgala-dev (7.1.3~r2209+pkg90~daily~ubuntu22.04.1) ...
Setting up gir1.2-gtk-4.0:amd64 (4.6.9+ds-0ubuntu0.22.04.1) ...
Setting up systemd-sysv (249.11-0ubuntu3.12) ...
Setting up libglx-mesa0:amd64 (23.2.1-1ubuntu3.1~22.04.2) ...
Setting up libgranite7:amd64 (7.4.0+r2506+pkg136~daily~ubuntu22.04.1) ...
Setting up g++-11 (11.4.0-1ubuntu1~22.04) ...
Setting up gir1.2-granite-7.0 (7.4.0+r2506+pkg136~daily~ubuntu22.04.1) ...
Setting up libgtk-4-dev:amd64 (4.6.9+ds-0ubuntu0.22.04.1) ...
Setting up valadoc (0.56.16-0ubuntu1~22.04~valateam0) ...
Setting up libfreetype6-dev:amd64 (2.11.1+dfsg-1ubuntu0.2) ...
Setting up libpam-systemd:amd64 (249.11-0ubuntu3.12) ...
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
Setting up libgranite-7-dev (7.4.0+r2506+pkg136~daily~ubuntu22.04.1) ...
Setting up elementary-sdk (1.521+r592~daily~ubuntu7.1.1) ...
Processing triggers for bamfdaemon (0.5.6+22.04.20220217-0ubuntu1) ...
Rebuilding /usr/share/applications/bamf-2.index...
Processing triggers for desktop-file-utils (0.26-1ubuntu3) ...
Processing triggers for libc-bin (2.35-0ubuntu3.6) ...
Processing triggers for dbus (1.12.20-2ubuntu4.1) ...
Processing triggers for libgdk-pixbuf-2.0-0:amd64 (2.42.8+dfsg-1ubuntu0.2) ...
Processing triggers for ca-certificates (20230311ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
E: Unable to correct problems, you have held broken packages.
```