### PR TITLE
DLNAPage: Fix status switch turned off on plug destruction or system reboot

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,5 +2,5 @@ src/Plug.vala
 src/Widgets/DLNAPage.vala
 src/Widgets/BluetoothPage.vala
 src/Backend/RygelStartupManager.vala
-src/Backend/RygelDBusInterface.vala
 src/Backend/RygelConfigFile.vala
+src/Backend/SharingDBusInterface.vala

--- a/src/Backend/RygelStartupManager.vala
+++ b/src/Backend/RygelStartupManager.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2015 elementary Developers (https://launchpad.net/elementary)
+ * Copyright (c) 2011-2024 elementary, Inc. (https://elementaryos.org)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -23,9 +23,11 @@ public class Sharing.Backend.RygelStartupManager : Object {
 
     construct {
         try {
-            sharing = Bus.get_proxy_sync (BusType.SESSION,
-                                          SharingDBusInterface.SERVICE_NAME,
-                                          SharingDBusInterface.OBJECT_PATH);
+            sharing = Bus.get_proxy_sync (
+                BusType.SESSION,
+                SharingDBusInterface.SERVICE_NAME,
+                SharingDBusInterface.OBJECT_PATH
+            );
         } catch (Error e) {
             warning ("Getting Sharing proxy failed: %s", e.message);
         }

--- a/src/Backend/SharingDBusInterface.vala
+++ b/src/Backend/SharingDBusInterface.vala
@@ -17,10 +17,20 @@
  * Boston, MA 02110-1301 USA.
  */
 
-[DBus (name = "org.gnome.Rygel1")]
-public interface Sharing.Backend.RygelDBusInterface : Object {
-    public const string SERVICE_NAME = "org.gnome.Rygel1";
-    public const string OBJECT_PATH = "/org/gnome/Rygel1";
+[DBus (name = "org.gnome.SettingsDaemon.Sharing")]
+public interface Sharing.Backend.SharingDBusInterface : Object {
+    public struct SharingNetwork {
+        string uuid;
+        string network_name;
+        string carrier_type;
+    }
 
-    public abstract void shutdown () throws IOError;
+    public const string SERVICE_NAME = "org.gnome.SettingsDaemon.Sharing";
+    public const string OBJECT_PATH = "/org/gnome/SettingsDaemon/Sharing";
+
+    public abstract string current_network { owned get; }
+
+    public abstract void enable_service (string service_name) throws Error;
+    public abstract void disable_service (string service_name, string network) throws Error;
+    public abstract SharingNetwork[] list_networks (string service_name) throws Error;
 }

--- a/src/Widgets/DLNAPage.vala
+++ b/src/Widgets/DLNAPage.vala
@@ -30,20 +30,20 @@ public class Sharing.Widgets.DLNAPage : Switchboard.SettingsPage {
 
         child = box;
 
+        status_switch.active = rygel_startup_manager.get_service_enabled ();
         set_service_state ();
 
         status_switch.notify["active"].connect (() => {
+            /* Make sure the configuration file exists */
+            if (rygel_config_file.save ()) {
+                rygel_startup_manager.set_service_enabled.begin (status_switch.active);
+            }
+
             set_service_state ();
         });
     }
 
     private void set_service_state () {
-        /* Make sure the configuration file exists */
-        if (rygel_config_file.save ()) {
-            rygel_startup_manager.set_service_enabled.begin (status_switch.active);
-
-        }
-
         if (status_switch.active) {
             description = _("While enabled, the following media libraries are shared to compatible devices in your network.");
             status = _("Enabled");

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,8 +3,8 @@ plug_files = files(
     'Widgets/DLNAPage.vala',
     'Widgets/BluetoothPage.vala',
     'Backend/RygelStartupManager.vala',
-    'Backend/RygelDBusInterface.vala',
-    'Backend/RygelConfigFile.vala'
+    'Backend/RygelConfigFile.vala',
+    'Backend/SharingDBusInterface.vala'
 )
 
 switchboard_dep = dependency('switchboard-3')


### PR DESCRIPTION
Fixes #73
Fixes #45

Use Sharing DBus service to enable/disable Rygel instead of creating the autostart file, because the autostart file is deleted by GSD while its initialization.