### PR TITLE
DLNAPage: rework copy

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -88,6 +88,7 @@ public class Sharing.Plug : Switchboard.Plug {
     public override async Gee.TreeMap<string, string> search (string search) {
         var search_results = new Gee.TreeMap<string, string> ((GLib.CompareDataFunc<string>)strcmp, (Gee.EqualDataFunc<string>)str_equal);
         search_results.set ("%s → %s".printf (display_name, _("Media Streaming")), "");
+        search_results.set ("%s → %s".printf (display_name, _("DLNA and UPnP")), "");
         search_results.set ("%s → %s".printf (display_name, _("Bluetooth")), "");
         return search_results;
     }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -87,7 +87,7 @@ public class Sharing.Plug : Switchboard.Plug {
     /* 'search' returns results like ("Keyboard → Behavior → Duration", "keyboard<sep>behavior") */
     public override async Gee.TreeMap<string, string> search (string search) {
         var search_results = new Gee.TreeMap<string, string> ((GLib.CompareDataFunc<string>)strcmp, (Gee.EqualDataFunc<string>)str_equal);
-        search_results.set ("%s → %s".printf (display_name, _("Media library")), "");
+        search_results.set ("%s → %s".printf (display_name, _("Media Streaming")), "");
         search_results.set ("%s → %s".printf (display_name, _("Bluetooth")), "");
         return search_results;
     }

--- a/src/Widgets/DLNAPage.vala
+++ b/src/Widgets/DLNAPage.vala
@@ -49,7 +49,7 @@ public class Sharing.Widgets.DLNAPage : Switchboard.SettingsPage {
             status = _("Enabled");
             status_type = SUCCESS;
         } else {
-            description = _("Media libraries are unshared and can't be streamed to other devices.");
+            description = _("Media libraries are currently unshared and can't be streamed to other devices.");
             status = _("Disabled");
             status_type = OFFLINE;
         }

--- a/src/Widgets/DLNAPage.vala
+++ b/src/Widgets/DLNAPage.vala
@@ -12,7 +12,7 @@ public class Sharing.Widgets.DLNAPage : Switchboard.SettingsPage {
     }
 
     construct {
-        title = _("Media Library");
+        title = _("Media Streaming");
         icon = new ThemedIcon ("applications-multimedia");
         show_end_title_buttons = true;
 
@@ -45,11 +45,11 @@ public class Sharing.Widgets.DLNAPage : Switchboard.SettingsPage {
 
     private void set_service_state () {
         if (status_switch.active) {
-            description = _("While enabled, the following media libraries are shared to compatible devices in your network.");
+            description = _("The selected libraries are available to stream on compatible DLNA-enabled devices on your local network such as TVs and game consoles.");
             status = _("Enabled");
             status_type = SUCCESS;
         } else {
-            description = _("While disabled, the selected media libraries are unshared, and it won't stream files from your computer to other devices.");
+            description = _("Media libraries are unshared and can't be streamed to other devices.");
             status = _("Disabled");
             status_type = OFFLINE;
         }


### PR DESCRIPTION
Fixes #26 

* Rename from "Media library" to "Media Streaming"
* Rework copy to mention DLNA
* Make enabled and disabled copy more obviously different so that it's clear it has changed

![Screenshot from 2024-06-03 20 31 46](https://github.com/elementary/switchboard-plug-sharing/assets/7277719/0b0efab6-9783-4b39-ba8a-97ac6db4ae71)
![Screenshot from 2024-06-03 20 34 34](https://github.com/elementary/switchboard-plug-sharing/assets/7277719/be6201fe-03c3-4d2e-810a-7257fa34265e)
